### PR TITLE
[PR] 월간 날짜채우기 작성 완료

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -44,13 +44,13 @@ body {
 
 /* ====== 캘린더 페이지 콘텐츠 스타일 ====== */
 .calendar {
-  border: 1px solid yellowgreen;
+  /* border: 1px solid yellowgreen; */
   width: 1500px;
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  margin: 50px;
+  /* margin: 50px; */
   color: var(--GRAY900);
   font-size: 14px;
 }
@@ -152,6 +152,7 @@ body {
   border-left: 1px solid var(--GRAY100);
 }
 .date-container {
+  flex-flow: row wrap;
   display: flex;
   width: 1400px;
 }
@@ -160,7 +161,7 @@ body {
   border-bottom: 1px solid var(--GRAY100);
   border-right: 1px solid var(--GRAY100);
   width: calc(100% / 7);
-  height: 150px;
+  height: 130px;
   position: relative;
   padding-top: 8px;
 }
@@ -175,7 +176,7 @@ body {
 
 }
 /* 오늘 날짜 도형 */
-.circle {
+.today-circle {
   width: 25px;
   height: 25px;
   display: flex;
@@ -188,4 +189,8 @@ body {
   left: 1px;
   top: 1px;
   color: #fff;
+}
+/* 이전, 다음 달은 비활성화 */
+.inactive {
+  opacity: 0.3;
 }

--- a/html/calendar.html
+++ b/html/calendar.html
@@ -7,6 +7,7 @@
 	<title>Calendar</title>
 	<link rel="stylesheet" href="../css/header.css">
 	<link rel="stylesheet" href="../css/calendar.css">
+	<script src="../js/calendar.js" defer></script>
 </head>
 
 <body>
@@ -85,16 +86,16 @@
 					</div>
 					<!-- 캘린더 날짜 (동적) -->
 					<div class="date-container">
-						<div class="date-box"><span class="date-text">1</span></div>
+						<!-- <div class="date-box"><span class="date-text">1</span></div>
 						<div class="date-box"><span class="date-text">2</span></div>
 						<div class="date-box"><span class="date-text">3</span></div>
 						<div class="date-box"><span class="date-text">4</span></div>
 						<div class="date-box">
 							<span class="date-text">5</span>
-							<div class="circle"><span class="today">5</span></div>
+							<div class="today-circle">5</div>
 						</div>
 						<div class="date-box"><span class="date-text">6</span></div>
-						<div class="date-box"><span class="date-text">7</span></div>
+						<div class="date-box"><span class="date-text">7</span></div> -->
 					</div>
 				</div>
 			</section>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,100 +1,129 @@
+// 현재 기준 날짜 및 시간
 let date = new Date();
+const todayYear = dateNow.getFullYear();
+const todayMonth = dateNow.getMonth();
+const todayDate = dateNow.getDate();
 
 //=====함수 정의 =====//
 
-// inactive 클래스 추가하는 함수 
-// 캘린더에 표시된 이번달 = 지난달 말 + 이번달 + 다음달 초 (dates 배열)  
+// inactive 클래스 추가하는 함수
+// 캘린더에 표시된 이번달 = 지난달 말 + 이번달 + 다음달 초 (dates 배열)
 const addInactiveClass = (dates) => {
   // .date-container 요소 후손 중에서 찾기
-  const $dateContainer = document.querySelector('.date-container');
+  const $dateContainer = document.querySelector(".date-container");
   // iterate  date 요소)
   dates.forEach((date, index) => {
     // currentMonth: false인 span 태그에 inactive 클래스 추가
     if (!date.currentMonth) {
-      const $spanDateText = $dateContainer.querySelector(`span[data-date-idx="${index}"]`);
-      $spanDateText.classList.add('inactive');
+      const $spanDateText = $dateContainer.querySelector(
+        `span[data-date-idx="${index}"]`
+      );
+      $spanDateText.classList.add("inactive");
     }
-  });    
-}
+  });
+};
+// 오늘 날짜가 현재 뷰에 있다면 div.today-circle 추가하는 함수
+const addTodayCircle = (dates) => {
+  // datesView에서 오늘 날짜 인덱스 구하기
+  const todayIndex = dates.findIndex(
+    ({ year, month, date }) =>
+      year === todayYear && month === todayMonth + 1 && date === todayDate
+  );
 
-// 캘린더 뷰에서 표시될 날짜 구하는 함수 (6주 * 7요일 = 총 42칸)
-const renderCalendarView = () => {
-  // 캘린더 뷰 기본값은 현재시각 기준 연월
-  const viewYear = date.getFullYear();
-  const viewMonth = date.getMonth();
-  
-  // 캘린더 헤더 제목은 뷰 기준으로 변경
-  // 버튼 고려해서 수정할 예정
-  document.querySelector('.year-month').textContent = `${viewYear}년 ${viewMonth + 1}월`;
-  
+  // 현재 뷰에 오늘 날짜가 있다면 태그 추가, 없으면 변화 없음
+  if (todayIndex > -1) {
+    const $todaySpan = document.querySelector(
+      `span[data-date-idx="${todayIndex}"]`
+    );
+
+    // div.today-circle 태그 생성
+    const $todayCircle = document.createElement("div");
+    $todayCircle.classList.add("today-circle");
+    $todayCircle.textContent = $todaySpan.textContent;
+
+    // 오늘 날짜 div.date-box에 div.today-circle 태그 추가
+    $todaySpan.parentElement.appendChild($todayCircle);
+  }
+};
+const generateDatesView = (year, month) => {
   // 지난 달 마지막 날, 이번 달 마지막 날
   // new Date(year, monthIndex, day);
   // 세번째 인수 0은 이전 달의 마지막 날 의미
-  const prevLast = new Date(viewYear, viewMonth, 0);
-  const currLast = new Date(viewYear, viewMonth + 1, 0);
-  
+  const prevLast = new Date(year, month, 0);
+  const currLast = new Date(year, month + 1, 0);
+
   // 지난 달 마지막 날짜와 요일,
   // 이번 달 마지막 날짜 구하기
   const prevLastDate = prevLast.getDate();
   const prevLastDay = prevLast.getDay();
-  
+
   const currLastDate = currLast.getDate();
   // const currLastDay = currLast.getDay();
-  
+
   // 지난 달 말 + 이번 달 전체 + 다음 달 초
   // 이번 달 1월이 아니면 그대로, 1월이면 연도-1년 12월
-  const prevDates = Array
-    .from({ length: prevLastDay + 1 }, 
-      (_, index) => ({ 
-        year: viewMonth !== 0 ? viewYear : viewYear - 1,
-        month: viewMonth !== 0 ? viewMonth : viewMonth + 12,
-        date: prevLastDate - prevLastDay + index,
-        currentMonth: false,
-      }));
-  const currDates = Array
-    .from({ length: currLastDate }, 
-      (_, index) => ({
-        year: viewYear,
-        month: viewMonth + 1,
-        date: index + 1,
-        currentMonth: true,
-      }));
+  const prevDates = Array.from({ length: prevLastDay + 1 }, (_, index) => ({
+    year: month !== 0 ? year : year - 1,
+    month: month !== 0 ? month : month + 12,
+    date: prevLastDate - prevLastDay + index,
+    currentMonth: false,
+  }));
+  const currDates = Array.from({ length: currLastDate }, (_, index) => ({
+    year: year,
+    month: month + 1,
+    date: index + 1,
+    currentMonth: true,
+  }));
   // 이번 달 12월이 아니면 그대로, 12월이면 연도+1년 1월
-  const nextDates = Array
-      .from({ length: 42 - prevDates.length - currDates.length }, 
-        (_, index) => ({
-          year: viewMonth + 1 !== 12 ? viewYear : viewYear + 1,
-          month: viewMonth + 1 !== 12 ? viewMonth + 2 : viewMonth + 2 - 12,
-          date: index + 1,
-          currentMonth: false,
-        }));
-        
+  const nextDates = Array.from(
+    { length: 42 - prevDates.length - currDates.length },
+    (_, index) => ({
+      year: month + 1 !== 12 ? year : year + 1,
+      month: month + 1 !== 12 ? month + 2 : month + 2 - 12,
+      date: index + 1,
+      currentMonth: false,
+    })
+  );
+
   // 배열 합치기 : 지난 달 말 + 이번 달 전체 + 다음 달 초
-  const dates = [...prevDates, ...currDates, ...nextDates];
-        
+  return [...prevDates, ...currDates, ...nextDates];
+};
+
+// 캘린더뷰 날짜 렌더링 함수 (6주 * 7요일 = 총 42칸)
+const renderCalendarView = () => {
+  // 캘린더뷰 초기값은 현재 기준 연월
+  const viewYear = todayYear;
+  const viewMonth = todayMonth;
+
+  // 캘린더 헤더 제목은 뷰 기준으로 변경
+  // 버튼 고려해서 수정할 예정
+  document.querySelector(".year-month").textContent = `${viewYear}년 ${viewMonth + 1}월`;
+
+  // datesView 배열 생성
+  const datesView = generateDatesView(viewYear, viewMonth);
+
   // Dates 태그 형태로 정리
-  const tagDates = dates.map((date, i) => {
+  const tagDates = datesView.map((date, i) => {
     date.id = i; // 원본 배열의 객체마다 id 추가
     return `<div class="date-box"><span class="date-text" data-date-idx="${i}">${date.date}</span></div>`;
-  })
+  });
 
   // Dates 화면 렌더링
-  document.querySelector('.date-container').innerHTML = tagDates.join('');
-  
-  // 이번 달이 아닌 날짜만 흐리게 스타일 변경하는 클래스 추가
-  addInactiveClass(dates);
+  document.querySelector(".date-container").innerHTML = tagDates.join("");
 
-}
+  // viewMonth 아닌 날짜만 흐리게 스타일 변경하는 클래스 추가
+  addInactiveClass(datesView);
 
+  // 현재 달과 viewMonth가 일치할 때만 함수 실행
+  if (todayMonth === viewMonth) {
+    // 오늘 날짜 div.today-circle 추가 함수
+    addTodayCircle(datesView);
+  }
+};
 
 // 지난 달 이동 함수 (버튼)
 // 다음 달 이동 함수 (버튼)
 // 오늘 이동 함수 (버튼)
-
-
-// 오늘 날짜 클래스 토글? 함수
-
-
 
 //=== 함수 실행 영역
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -50,8 +50,6 @@ const addTodayCircle = (dates) => {
 
     // 오늘 날짜 div.date-box에 div.today-circle 태그 추가
     $todaySpan.parentElement.appendChild($todayCircle);
-    console.log($todayCircle.style.backgroundColor);
-    console.log($todayCircle);
   }
 };
 const generateDatesView = (year, month) => {
@@ -132,17 +130,11 @@ const renderCalendarView = (year = todayYear, month = todayMonth) => {
   }
 };
 
-// 지난 달 이동 함수 (버튼)
-// 다음 달 이동 함수 (버튼)
-// 오늘 이동 함수 (버튼)
-
-
 // 이전 달 또는 다음 달로 이동하는 함수
 const goToMonth = (direction) => {
   // 현재 월에 방향을 더하고, 12로 나눈 나머지를 새로운 월로 설정
   viewMonth = (viewMonth + direction + 12) % 12;
-  
-  console.log(viewMonth);
+
   // 이전 달로 이동할 때 연도 조정
   if (viewMonth === 11 && direction === -1) {
     viewYear--;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -153,15 +153,15 @@ const goToMonth = (direction) => {
 renderCalendarView();
 
 // 이전 달 버튼 클릭 이벤트 핸들러
-document.querySelector('.go-prev').addEventListener('click', () => {
+document.querySelector('.go-prev').parentElement.addEventListener('click', () => {
   goToMonth(-1); // 방향을 -1로 설정하여 이전 달로 이동
 });
 
 // 다음 달 버튼 클릭 이벤트 핸들러
-document.querySelector('.go-next').addEventListener('click', () => {
+document.querySelector('.go-next').parentElement.addEventListener('click', () => {
   goToMonth(1); // 방향을 1로 설정하여 다음 달로 이동
 });
 // 오늘 버튼 클릭 이벤트 핸들러
-document.querySelector('.go-today').addEventListener('click', () => {
+document.querySelector('.go-today').parentElement.addEventListener('click', () => {
   renderCalendarView(todayYear, todayMonth);
 })

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -4,6 +4,9 @@ const todayYear = dateNow.getFullYear();
 const todayMonth = dateNow.getMonth();
 const todayDate = dateNow.getDate();
 
+let viewYear = todayYear;
+let viewMonth = todayMonth;
+
 //=====함수 정의 =====//
 
 // inactive 클래스 추가하는 함수
@@ -96,10 +99,10 @@ const generateDatesView = (year, month) => {
 };
 
 // 캘린더뷰 날짜 렌더링 함수 (6주 * 7요일 = 총 42칸)
-const renderCalendarView = () => {
+const renderCalendarView = (year = todayYear, month = todayMonth) => {
   // 캘린더뷰 초기값은 현재 기준 연월
-  const viewYear = todayYear;
-  const viewMonth = todayMonth;
+  viewYear = year;
+  viewMonth = month;
 
   // 캘린더 헤더 제목은 뷰 기준으로 변경
   // 버튼 고려해서 수정할 예정
@@ -139,6 +142,7 @@ const goToMonth = (direction) => {
   // 현재 월에 방향을 더하고, 12로 나눈 나머지를 새로운 월로 설정
   viewMonth = (viewMonth + direction + 12) % 12;
   
+  console.log(viewMonth);
   // 이전 달로 이동할 때 연도 조정
   if (viewMonth === 11 && direction === -1) {
     viewYear--;
@@ -148,7 +152,7 @@ const goToMonth = (direction) => {
     viewYear++;
   }
   
-  renderCalendarView(); // 달력 다시 렌더링
+  renderCalendarView(viewYear, viewMonth); // 달력 다시 렌더링
 };
 
 
@@ -167,5 +171,5 @@ document.querySelector('.go-next').addEventListener('click', () => {
 });
 // 오늘 버튼 클릭 이벤트 핸들러
 document.querySelector('.go-today').addEventListener('click', () => {
-
+  renderCalendarView(todayYear, todayMonth);
 })

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,0 +1,86 @@
+let date = new Date();
+
+//=====함수 정의 =====//
+
+
+const renderCalendar = () => {
+  // 오늘 기준 연도, 월 구하기
+  const viewYear = date.getFullYear();
+  const viewMonth = date.getMonth();
+  
+  // 캘린더 헤더 제목 오늘 기준으로 변경
+  document.querySelector('.year-month').textContent = `${viewYear}년 ${viewMonth + 1}월`;
+  
+  // 지난 달 마지막 날, 이번 달 마지막 날
+  // new Date(year, monthIndex, day);
+  // 세번째 인수 0은 이전 달의 마지막 날 의미
+  const prevLast = new Date(viewYear, viewMonth, 0);
+  const currLast = new Date(viewYear, viewMonth + 1, 0);
+  
+  // 이전 달 마지막 날짜와 요일,
+  // 이번 달 마지막 날짜 구하기
+  const prevLastDate = prevLast.getDate();
+  const prevLastDay = prevLast.getDay();
+  
+  const currLastDate = currLast.getDate();
+  // const currLastDay = currLast.getDay();
+  
+  // 이번 달 달력에서 표시될 날짜 구하기 6주 * 7요일
+  // 지난 달 마지막 주 + 이번 달 전체 + 다음 달 첫 주
+  // 이번 달 1월이 아니면 그대로, 1월이면 연도-1년 12월
+  const prevDates = Array
+    .from({ length: prevLastDay + 1 }, 
+      (_, index) => ({ 
+        year: viewMonth !== 0 ? viewYear : viewYear - 1,
+        month: viewMonth !== 0 ? viewMonth : viewMonth + 12,
+        date: prevLastDate - prevLastDay + index,
+        currentMonth: false,
+      }));
+  const currDates = Array
+    .from({ length: currLastDate }, 
+      (_, index) => ({
+        year: viewYear,
+        month: viewMonth + 1,
+        date: index + 1,
+        currentMonth: true,
+      }));
+      // 이번 달 12월이 아니면 그대로, 12월이면 연도+1년 1월
+  const nextDates = Array
+      .from({ length: 42 - prevDates.length - currDates.length }, 
+        (_, index) => ({
+          year: viewMonth + 1 !== 12 ? viewYear : viewYear + 1,
+          month: viewMonth + 1 !== 12 ? viewMonth + 2 : viewMonth + 2 - 12,
+          date: index + 1,
+          currentMonth: false,
+        }));
+        
+  // 배열 합치기 : 지난 달 마지막 주 + 이번 달 전체 + 다음 달 첫 주
+  const dates = [...prevDates, ...currDates, ...nextDates];
+        
+  // Dates 태그 형태로 정리
+  const tagDates = dates.map((date, i) => {
+    date.id = i; // id 추가
+    return `<div class="date-box"><span class="date-text" data-date-idx="${i}">${date.date}</span></div>`;
+  })
+
+  // Dates 화면 렌더링
+  document.querySelector('.date-container').innerHTML = tagDates.join('');
+  
+  // 이번 달이 아닌 날짜 흐리게 변경 클래스 추가
+  // isNotCurrMonth(dates);
+
+}
+
+
+// 지난 달 이동 함수 (버튼)
+// 다음 달 이동 함수 (버튼)
+// 오늘 이동 함수 (버튼)
+
+
+// 오늘 날짜 클래스 토글? 함수
+
+
+
+//=== 함수 실행 영역
+
+renderCalendar();

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,5 +1,5 @@
 // 현재 기준 날짜 및 시간
-let date = new Date();
+let dateNow = new Date();
 const todayYear = dateNow.getFullYear();
 const todayMonth = dateNow.getMonth();
 const todayDate = dateNow.getDate();
@@ -36,13 +36,19 @@ const addTodayCircle = (dates) => {
       `span[data-date-idx="${todayIndex}"]`
     );
 
+    // computed style에서 색상 값 가져오기
+    const textColor = window.getComputedStyle($todaySpan).color;
+
     // div.today-circle 태그 생성
     const $todayCircle = document.createElement("div");
     $todayCircle.classList.add("today-circle");
     $todayCircle.textContent = $todaySpan.textContent;
+    $todayCircle.style.backgroundColor = textColor;
 
     // 오늘 날짜 div.date-box에 div.today-circle 태그 추가
     $todaySpan.parentElement.appendChild($todayCircle);
+    console.log($todayCircle.style.backgroundColor); 
+    console.log($todayCircle); 
   }
 };
 const generateDatesView = (year, month) => {

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -47,8 +47,8 @@ const addTodayCircle = (dates) => {
 
     // 오늘 날짜 div.date-box에 div.today-circle 태그 추가
     $todaySpan.parentElement.appendChild($todayCircle);
-    console.log($todayCircle.style.backgroundColor); 
-    console.log($todayCircle); 
+    console.log($todayCircle.style.backgroundColor);
+    console.log($todayCircle);
   }
 };
 const generateDatesView = (year, month) => {
@@ -103,7 +103,9 @@ const renderCalendarView = () => {
 
   // 캘린더 헤더 제목은 뷰 기준으로 변경
   // 버튼 고려해서 수정할 예정
-  document.querySelector(".year-month").textContent = `${viewYear}년 ${viewMonth + 1}월`;
+  document.querySelector(".year-month").textContent = `${viewYear}년 ${
+    viewMonth + 1
+  }월`;
 
   // datesView 배열 생성
   const datesView = generateDatesView(viewYear, viewMonth);
@@ -131,6 +133,39 @@ const renderCalendarView = () => {
 // 다음 달 이동 함수 (버튼)
 // 오늘 이동 함수 (버튼)
 
-//=== 함수 실행 영역
+
+// 이전 달 또는 다음 달로 이동하는 함수
+const goToMonth = (direction) => {
+  // 현재 월에 방향을 더하고, 12로 나눈 나머지를 새로운 월로 설정
+  viewMonth = (viewMonth + direction + 12) % 12;
+  
+  // 이전 달로 이동할 때 연도 조정
+  if (viewMonth === 11 && direction === -1) {
+    viewYear--;
+  }
+  // 다음 달로 이동할 때 연도 조정
+  if (viewMonth === 0 && direction === 1) {
+    viewYear++;
+  }
+  
+  renderCalendarView(); // 달력 다시 렌더링
+};
+
+
+//===== 함수 실행 영역 =====//
 
 renderCalendarView();
+
+// 이전 달 버튼 클릭 이벤트 핸들러
+document.querySelector('.go-prev').addEventListener('click', () => {
+  goToMonth(-1); // 방향을 -1로 설정하여 이전 달로 이동
+});
+
+// 다음 달 버튼 클릭 이벤트 핸들러
+document.querySelector('.go-next').addEventListener('click', () => {
+  goToMonth(1); // 방향을 1로 설정하여 다음 달로 이동
+});
+// 오늘 버튼 클릭 이벤트 핸들러
+document.querySelector('.go-today').addEventListener('click', () => {
+
+})

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -2,13 +2,29 @@ let date = new Date();
 
 //=====함수 정의 =====//
 
+// inactive 클래스 추가하는 함수 
+// 캘린더에 표시된 이번달 = 지난달 말 + 이번달 + 다음달 초 (dates 배열)  
+const addInactiveClass = (dates) => {
+  // .date-container 요소 후손 중에서 찾기
+  const $dateContainer = document.querySelector('.date-container');
+  // iterate  date 요소)
+  dates.forEach((date, index) => {
+    // currentMonth: false인 span 태그에 inactive 클래스 추가
+    if (!date.currentMonth) {
+      const $spanDateText = $dateContainer.querySelector(`span[data-date-idx="${index}"]`);
+      $spanDateText.classList.add('inactive');
+    }
+  });    
+}
 
-const renderCalendar = () => {
-  // 오늘 기준 연도, 월 구하기
+// 캘린더 뷰에서 표시될 날짜 구하는 함수 (6주 * 7요일 = 총 42칸)
+const renderCalendarView = () => {
+  // 캘린더 뷰 기본값은 현재시각 기준 연월
   const viewYear = date.getFullYear();
   const viewMonth = date.getMonth();
   
-  // 캘린더 헤더 제목 오늘 기준으로 변경
+  // 캘린더 헤더 제목은 뷰 기준으로 변경
+  // 버튼 고려해서 수정할 예정
   document.querySelector('.year-month').textContent = `${viewYear}년 ${viewMonth + 1}월`;
   
   // 지난 달 마지막 날, 이번 달 마지막 날
@@ -17,7 +33,7 @@ const renderCalendar = () => {
   const prevLast = new Date(viewYear, viewMonth, 0);
   const currLast = new Date(viewYear, viewMonth + 1, 0);
   
-  // 이전 달 마지막 날짜와 요일,
+  // 지난 달 마지막 날짜와 요일,
   // 이번 달 마지막 날짜 구하기
   const prevLastDate = prevLast.getDate();
   const prevLastDay = prevLast.getDay();
@@ -25,8 +41,7 @@ const renderCalendar = () => {
   const currLastDate = currLast.getDate();
   // const currLastDay = currLast.getDay();
   
-  // 이번 달 달력에서 표시될 날짜 구하기 6주 * 7요일
-  // 지난 달 마지막 주 + 이번 달 전체 + 다음 달 첫 주
+  // 지난 달 말 + 이번 달 전체 + 다음 달 초
   // 이번 달 1월이 아니면 그대로, 1월이면 연도-1년 12월
   const prevDates = Array
     .from({ length: prevLastDay + 1 }, 
@@ -44,7 +59,7 @@ const renderCalendar = () => {
         date: index + 1,
         currentMonth: true,
       }));
-      // 이번 달 12월이 아니면 그대로, 12월이면 연도+1년 1월
+  // 이번 달 12월이 아니면 그대로, 12월이면 연도+1년 1월
   const nextDates = Array
       .from({ length: 42 - prevDates.length - currDates.length }, 
         (_, index) => ({
@@ -54,20 +69,20 @@ const renderCalendar = () => {
           currentMonth: false,
         }));
         
-  // 배열 합치기 : 지난 달 마지막 주 + 이번 달 전체 + 다음 달 첫 주
+  // 배열 합치기 : 지난 달 말 + 이번 달 전체 + 다음 달 초
   const dates = [...prevDates, ...currDates, ...nextDates];
         
   // Dates 태그 형태로 정리
   const tagDates = dates.map((date, i) => {
-    date.id = i; // id 추가
+    date.id = i; // 원본 배열의 객체마다 id 추가
     return `<div class="date-box"><span class="date-text" data-date-idx="${i}">${date.date}</span></div>`;
   })
 
   // Dates 화면 렌더링
   document.querySelector('.date-container').innerHTML = tagDates.join('');
   
-  // 이번 달이 아닌 날짜 흐리게 변경 클래스 추가
-  // isNotCurrMonth(dates);
+  // 이번 달이 아닌 날짜만 흐리게 스타일 변경하는 클래스 추가
+  addInactiveClass(dates);
 
 }
 
@@ -83,4 +98,4 @@ const renderCalendar = () => {
 
 //=== 함수 실행 영역
 
-renderCalendar();
+renderCalendarView();


### PR DESCRIPTION

캘린더 뷰
: 사용자가 선택한 연도와 월에 맞는 달력을 렌더링 
  * 초기화면은 오늘 날짜 기준으로 작성됨

1.  캘린더 뷰를 기준으로 날짜 생성
2.  날짜 배열 생성 함수 (지난 달 말 + 이번 달 + 다음 달 초)
3.  이번 달이 아닌 날짜에 그레이아웃 스타일 (비활성화) 지정
4.  캘린더 뷰에 오늘 날짜가 있다면 도형으로 강조
5.  이전 버튼, 다음 버튼에 맞게 캘린더 뷰의 연월을 변경
6.  이전 버튼, 다음 버튼, 오늘 버튼 이벤트 핸들러 작성