### PR TITLE
[PR] 모달 할일추가 반복에 따라 메인 캘린더 렌더 기능 추가

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -33,6 +33,10 @@ button, input {
   --GRAY300: #CCC;
   --GRAY100: #EBEBEB;
   --RED500: #E85E36;
+  --BLUE100: #fafaff;
+  --BLUE300: #ccccff;
+  --BLUE500: #43CBFF;
+  --VIOL500: #7367F0;
 }
 body {
   /* font는 추후 상의 필요 */
@@ -53,6 +57,7 @@ body {
   /* margin: 50px; */
   color: var(--GRAY900);
   font-size: 14px;
+  background-color: var(--BLUE100);
 }
 
 
@@ -80,8 +85,9 @@ body {
   /* border-radius: 8px; */
   border: 1px solid var(--GRAY100);
   padding: 3px 8px;
-  color: var(--GRAY700)
-
+  color: var(--GRAY700);
+  background: #fff;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
 .header-calendar .nav-calendar a:first-child {
   border-radius: 8px 0 0 8px;
@@ -93,8 +99,9 @@ body {
   border-radius: 0 8px 8px 0;
 }
 .nav-calendar a:hover {
-  background: var(--GRAY100);
-  border-color: var(--GRAY300);
+  background: var(--VIOL500);
+  border-color: var(--VIOL500);
+  color: #fff;
 }
 .header-calendar .nav-btn {
   border: 0;
@@ -106,8 +113,8 @@ body {
   /* padding: 3px 10px; */
 }
 .header-calendar .nav-btn:nth-child(2) {
-  border-left: 1px solid var(--GRAY100);
-  border-right: 1px solid var(--GRAY100);
+  border-left: 1px solid;
+  border-right: 1px solid;
 }
 
 .header-calendar .nav-btn i {
@@ -121,6 +128,7 @@ body {
 /* ====== 캘린더 메인 스타일 ====== */ 
 .main-calendar {
   /* border: 1px solid blue; */
+  background: #fff;
 }
 /* days-containier 스타일 (요일) */
 .days-container {
@@ -167,7 +175,9 @@ body {
 }
 
 .date-container .date-box:hover {
-  background: var(--GRAY100);
+  /* background: var(--GRAY100); */
+  background: var(--BLUE100);
+  border: 1px solid var(--BLUE300);
 }
 
 .date-container .date-box .date-text {
@@ -183,12 +193,14 @@ body {
   justify-content: center;
   align-items: center;
   text-align: center;
-  background: var(--GRAY900);
+  /* background: var(--GRAY900); */
+  background: linear-gradient(135deg, var(--BLUE500), #7367F0);
   border-radius: 50%;
   position: absolute;
   left: 1px;
   top: 1px;
   color: #fff;
+  box-shadow: 1px 1px 2px 1px #d1d3df;
 }
 /* 이전, 다음 달은 비활성화 */
 .inactive {
@@ -197,16 +209,26 @@ body {
 
 /* 캘린더 할일 리스트 스타일 */
 .date-todo {
-  margin-top: 10px;
+  margin-top: 20px;
+  position: relative;
 }
 .cal-list {
-  border-right: 1px solid #a19cd3;
-  border-bottom: 1px solid #a19cd3;
+  /* border-right: 1px solid #b9c6ec; */
+  /* border-bottom: 1px solid #bfc5d8; */
   /* border-radius: 5px; */
-  background: #e0ddfc;
-  height: 30px;
+  background: #e4e8ff;
+  height: 25px;
   display: flex;
   align-items: center;
   padding: 7px;
   font-weight: 500;
+  font-size: 0.9em;
+  color: var(--GRAY700);
+  transition: 300ms;
+  z-index: 2;
+}
+.cal-list:hover {
+  transform: scale(1.05);
+  box-shadow: 1px 3px 5px 1px rgba(0, 0, 0, 0.3);
+  z-index: 10;
 }

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -232,3 +232,8 @@ body {
   box-shadow: 1px 3px 5px 1px rgba(0, 0, 0, 0.3);
   z-index: 10;
 }
+
+.repeat-option {
+  height: 30px;
+  line-height: 30px;
+}

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -194,3 +194,19 @@ body {
 .inactive {
   opacity: 0.3;
 }
+
+/* 캘린더 할일 리스트 스타일 */
+.date-todo {
+  margin-top: 10px;
+}
+.cal-list {
+  border-right: 1px solid #a19cd3;
+  border-bottom: 1px solid #a19cd3;
+  /* border-radius: 5px; */
+  background: #e0ddfc;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  padding: 7px;
+  font-weight: 500;
+}

--- a/html/calendar.html
+++ b/html/calendar.html
@@ -166,7 +166,7 @@
 					<div class="dropdown select-repeat">
 						<button class="btn repeat-btn">반복 안함</button>
 						<div id="drop-content" class="content-repeat">
-							<a href='#'>Menu1</a>
+							<a href='#'>매일</a>
 							<a href='#'>Menu2</a>
 							<a href='#'>Menu3</a>
 							<a href='#'>Menu4</a>

--- a/html/calendar.html
+++ b/html/calendar.html
@@ -226,7 +226,6 @@
 			$contentRepeat.classList.remove("show");
 		}, true);
 
-		// renderRepeatToCalendarView(todoList);
 	</script>
 </body>
 

--- a/html/calendar.html
+++ b/html/calendar.html
@@ -166,9 +166,9 @@
 					<div class="dropdown select-repeat">
 						<button class="btn repeat-btn">반복 안함</button>
 						<div id="drop-content" class="content-repeat">
-							<a href='#' class="repeat-daily">매일</a>
-							<a href='#' class="repeat-weekly">매주</a>
-							<a href='#' class="repeat-monthly">매월</a>
+							<a href='#' class="repeat-option repeat-daily">매일</a>
+							<a href='#' class="repeat-option repeat-weekly">매주</a>
+							<a href='#' class="repeat-option repeat-monthly">매월</a>
 							<!-- <a href='#'>Menu4</a>
 							<a href='#'>Menu5</a> -->
 						</div>

--- a/html/calendar.html
+++ b/html/calendar.html
@@ -88,16 +88,16 @@
 					</div>
 					<!-- 캘린더 날짜 (동적) -->
 					<div class="date-container">
-						<!-- <div class="date-box"><span class="date-text">1</span></div>
-						<div class="date-box"><span class="date-text">2</span></div>
-						<div class="date-box"><span class="date-text">3</span></div>
-						<div class="date-box"><span class="date-text">4</span></div>
-						<div class="date-box">
+						<!-- <div class="date-box" data-date-idx="0"><span class="date-text">1</span></div>
+						<div class="date-box" data-date-idx="1"><span class="date-text">2</span></div>
+						<div class="date-box" data-date-idx="2"><span class="date-text">3</span></div>
+						<div class="date-box" data-date-idx="3"><span class="date-text">4</span></div>
+						<div class="date-box" data-date-idx="4">
 							<span class="date-text">5</span>
 							<div class="today-circle">5</div>
 						</div>
-						<div class="date-box"><span class="date-text">6</span></div>
-						<div class="date-box"><span class="date-text">7</span></div> -->
+						<div class="date-box" data-date-idx="5"><span class="date-text">6</span></div>
+						<div class="date-box" data-date-idx="5"><span class="date-text">7</span></div> -->
 					</div>
 				</div>
 			</section>
@@ -166,11 +166,11 @@
 					<div class="dropdown select-repeat">
 						<button class="btn repeat-btn">반복 안함</button>
 						<div id="drop-content" class="content-repeat">
-							<a href='#'>매일</a>
-							<a href='#'>Menu2</a>
-							<a href='#'>Menu3</a>
-							<a href='#'>Menu4</a>
-							<a href='#'>Menu5</a>
+							<a href='#' class="repeat-daily">매일</a>
+							<a href='#' class="repeat-weekly">매주</a>
+							<a href='#' class="repeat-monthly">매월</a>
+							<!-- <a href='#'>Menu4</a>
+							<a href='#'>Menu5</a> -->
 						</div>
 					</div>
 				</div>
@@ -225,6 +225,8 @@
 			$contentCalendar.classList.remove("show");
 			$contentRepeat.classList.remove("show");
 		}, true);
+
+		// renderRepeatToCalendarView(todoList);
 	</script>
 </body>
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -115,7 +115,10 @@ const renderCalendarView = (year = todayYear, month = todayMonth) => {
   // Dates 태그 형태로 정리
   const tagDates = datesView.map((date, i) => {
     date.id = i; // 원본 배열의 객체마다 id 추가
-    return `<div class="date-box"><span class="date-text" data-date-idx="${i}">${date.date}</span></div>`;
+    return  `<div class="date-box">
+        <span class="date-text" data-date-idx="${i}">${date.date}</span>
+        <ul class="date-todo"></ul>
+      </div>`;
   });
 
   // Dates 화면 렌더링

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,4 +1,4 @@
-// import { renderRepeatToCalendarView, todoList } from "./calendar_todo";
+import { renderRepeatToCalendarView, todoList } from "./calendar_todo.js";
 
 // 현재 기준 날짜 및 시간
 let dateNow = new Date();
@@ -197,20 +197,23 @@ const renderWeeklyView = (e) => {
 renderCalendarView();
 // 초기화면: 이벤트 없이 weekly 렌더
 renderWeeklyView();
-// renderRepeatToCalendarView(todoList);
+renderRepeatToCalendarView(todoList);
 
 // 이전 달 버튼 클릭 이벤트 핸들러
 document.querySelector('.go-prev').parentElement.addEventListener('click', () => {
   goToMonth(-1); // 방향을 -1로 설정하여 이전 달로 이동
+  renderRepeatToCalendarView(todoList);
 });
 
 // 다음 달 버튼 클릭 이벤트 핸들러
 document.querySelector('.go-next').parentElement.addEventListener('click', () => {
   goToMonth(1); // 방향을 1로 설정하여 다음 달로 이동
+  renderRepeatToCalendarView(todoList);
 });
 // 오늘 버튼 클릭 이벤트 핸들러
 document.querySelector('.go-today').parentElement.addEventListener('click', () => {
   renderCalendarView(todayYear, todayMonth);
+  renderRepeatToCalendarView(todoList);
 });
 
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,3 +1,5 @@
+// import { renderRepeatToCalendarView, todoList } from "./calendar_todo";
+
 // 현재 기준 날짜 및 시간
 let dateNow = new Date();
 const todayYear = dateNow.getFullYear();
@@ -12,15 +14,14 @@ let viewMonth = todayMonth;
 // inactive 클래스 추가하는 함수
 // 캘린더에 표시된 이번달 = 지난달 말 + 이번달 + 다음달 초 (dates 배열)
 const addInactiveClass = (dates, ele) => {
-  // .date-container 요소 후손 중에서 찾기
-  // const $dateContainer = document.querySelector(".date-container");
+  // ele(.date-container) 요소 후손 중에서 찾기
   // iterate  date 요소
   dates.forEach((date, index) => {
     // currentMonth: false인 span 태그에 inactive 클래스 추가
     if (!date.currentMonth) {
       const $spanDateText = ele.querySelector(
-        `span[data-date-idx="${index}"]`
-      );
+        `div[data-date-idx="${index}"]`
+      ).firstElementChild;
       $spanDateText.classList.add("inactive");
     }
   });
@@ -36,8 +37,8 @@ const addTodayCircle = (dates, ele) => {
   // 현재 뷰에 오늘 날짜가 있다면 태그 추가, 없으면 변화 없음
   if (todayIndex > -1) {
     const $todaySpan = ele.querySelector(
-      `span[data-date-idx="${todayIndex}"]`
-    );
+      `div[data-date-idx="${todayIndex}"]`
+    ).firstElementChild;
 
     // computed style에서 색상 값 가져오기
     const textColor = window.getComputedStyle($todaySpan).color;
@@ -115,14 +116,14 @@ const renderCalendarView = (year = todayYear, month = todayMonth) => {
   // Dates 태그 형태로 정리
   const tagDates = datesView.map((date, i) => {
     date.id = i; // 원본 배열의 객체마다 id 추가
-    return  `<div class="date-box">
-        <span class="date-text" data-date-idx="${i}">${date.date}</span>
+    return  `<div class="date-box" data-date-idx="${i}">
+        <span class="date-text" data-date="${date.year}-${date.month}">${date.date}</span>
         <ul class="date-todo"></ul>
       </div>`;
   });
 
   // Dates 화면 렌더링
-  // document.querySelector(".date-container").innerHTML = tagDates.join("");
+  // ele은 div.date-container (메인 캘린더, 푸터 등 여러 개)
   const arr = document.querySelectorAll(".date-container");
   arr.forEach(ele => {
    // if (ele.classList.contains("weekly"))//weekly 예외처리(수정)
@@ -138,14 +139,6 @@ const renderCalendarView = (year = todayYear, month = todayMonth) => {
     }
   })
 
-  // // viewMonth 아닌 날짜만 흐리게 스타일 변경하는 클래스 추가
-  // addInactiveClass(datesView);
-
-  // // 현재 달과 viewMonth가 일치할 때만 함수 실행
-  // if (todayMonth === viewMonth) {
-  //   // 오늘 날짜 div.today-circle 추가 함수
-  //   addTodayCircle(datesView);
-  // }
 };
 
 // 이전 달 또는 다음 달로 이동하는 함수
@@ -177,7 +170,7 @@ const renderWeeklyView = (e) => {
 
   // 1-1. data-date-idx 는 언제나 달력에서 0 ~ 41까지 고정됨
   // 1-2. data-date-idx 를 7로 나눈 나머지가 해당 날짜의 요일
-  const selectedDateIdx = $selectedDateBox.firstElementChild.dataset.dateIdx;
+  const selectedDateIdx = $selectedDateBox.dataset.dateIdx;
   const selectedDay = selectedDateIdx % 7;
 
   // 2. 선택한 날짜가 있는 주의 첫번째 날짜(일요일)의 data-date-idx 추출
@@ -204,6 +197,7 @@ const renderWeeklyView = (e) => {
 renderCalendarView();
 // 초기화면: 이벤트 없이 weekly 렌더
 renderWeeklyView();
+// renderRepeatToCalendarView(todoList);
 
 // 이전 달 버튼 클릭 이벤트 핸들러
 document.querySelector('.go-prev').parentElement.addEventListener('click', () => {

--- a/js/calendar_todo.js
+++ b/js/calendar_todo.js
@@ -21,6 +21,11 @@ const todoList = [
     time: { year: 2024, month: 4, date: 10, day: 3 },
     repeat: 3,
   },
+  {
+    title: "할일 5",
+    time: { year: 2024, month: 4, date: 27, day: 6 },
+    repeat: 0,
+  },
 ];
 let todo = {
   title: "할일",
@@ -106,7 +111,7 @@ const getSelectedDate = (e) => {
 // 3-1. 버튼에 선택한 반복 옵션 표시,
 //      todo 객체에 repeat 옵션값 저장 (추가/수정될 투두리스트)
 // 0: 반복 안함, 1: 매일, 2: 매주, 3: 매월
-const getReccurrenceOption = (target) => {
+const setReccurrenceOption = (target) => {
   const optionText = target.textContent;
   let $btnRepeat = target.closest(".repeat-btn");
   let repeatOptionNum = 0;
@@ -135,37 +140,38 @@ const renderRepeatToCalendarView = (todoList) => {
   // 메인 캘린더의 date-container 선택해서 date-box 배열로 저장
   const dateBoxArr = Array.from(document.querySelector("#main-content .date-container").children);
   
+  // 캘린더 뷰 기준 날짜마다 Date()와 date-box인덱스를 객체로 담은 배열 생성 
   const viewTimeArr = dateBoxArr.map(dateBox => {
     const {year, month, date} = getDateInfoFromSpan(dateBox.firstElementChild);
-    const dateBoxId = dateBox.dataset.dateIdx;
-    return { dateObj: new Date(year, month, date), dateBoxId };
+    const dateBoxId = +dateBox.dataset.dateIdx;
+    return { dateObj: new Date(`${year}-${month}-${date}`), dateBoxId };
   });
 
+  // 할일 리스트의 할일 마다 해당하는 날짜에 렌더
   todoList.forEach((todo) => {
     // todo의 날짜 구하기
-    const todoTime = new Date(todo.time.year, todo.time.month -1, todo.time.date).getTime();
+    const month = (todo.time.month > 1) ? todo.time.month - 1 : 0;
+    const todoTime = new Date(todo.time.year, month, todo.time.date, 0, 0, 0, 0);
     
     // todo의 repeat 값 따라 리스트 추가할 날짜만 필터
     const filteredViewTimeArr = viewTimeArr.filter(({dateObj: viewTime}, dateBoxId) => {
       let option = todo.repeat;
       // 매일 반복은 todoTime 이상의 viewTime만 필터링
-      if(option === 1) return viewTime.getTime() >= todoTime;
+      if(option === 1) return viewTime.getTime() >= todoTime.getTime();
       // 매주 반복은 todoTime 이상의 viewTime이면서 요일이 같을 때만 필터링
       else if(option === 2) {
-        console.log(todo.time.day);
-        return viewTime.getTime() >= todoTime && todo.time.day === viewTime.getDay();
+        return viewTime.getTime() >= todoTime.getTime() && todo.time.day === dateBoxId % 7;
       }
       // 매월 반복은 todoTime 이상의 viewTime이면서 날짜가 같을 때만 필터링
       else if(option === 3) return viewTime.getTime() >= todoTime && todo.time.date === viewTime.getDate();
-      else if(option === 0)return viewTime.getTime() === todoTime;  
+      else if(option === 0)return viewTime.getTime() === todoTime.getTime();  
       else return false;
     });
     
-
-    // todo 정보를 li 태그에 담기
     
     // 해당 날짜의 ul 자식요소로 li 태그 추가
     filteredViewTimeArr.forEach( ({dateBoxId}) => {
+      // todo 정보를 li 태그에 담기
       const $repeatLi = document.createElement("li");
       $repeatLi.textContent = todo.title;
       $repeatLi.classList.add("cal-list");
@@ -178,11 +184,6 @@ const renderRepeatToCalendarView = (todoList) => {
       // console.log($ul);
     });
   });
-
-
-  // date-container 전체반복해서 설정한 기간보다 뒤면 리스트태그 추가
-  // new Date(date.year, date.month, date.date) 로 크기 비교
-  // ul.date-todo appendChild li태그
 
 };
 
@@ -222,11 +223,10 @@ $selectRepeat.addEventListener("click", (e) => {
   $contentRepeat.classList.add("show");
 
   // e.target 드롭다운 옵션 조건 판단
-
-  getReccurrenceOption(e.target);
+  setReccurrenceOption(e.target);
   
 });
-// 투두리스트 추가 수정 삭제 마다 render
+// 투두리스트 추가 수정 삭제 마다 render 해야 함
 renderRepeatToCalendarView(todoList);
 
 export {todoList, renderRepeatToCalendarView};

--- a/js/calendar_todo.js
+++ b/js/calendar_todo.js
@@ -1,11 +1,55 @@
 import { goToMonth } from "./calendar.js";
 
+const todoList = [
+  {
+    title: "할일 1",
+    date: {year: 2024, month: 4, date: 21, day: 0},
+    repeat: 1
+  },
+  {
+    title: "할일 2",
+    date: {year: 2024, month: 4, date: 22, day: 1},
+    repeat: 0
+  },
+]
+let todo = {title: "할일 3", date: {year: 2024, month: 4, date: 21, day: 0}, repeat: 0};
 
 // 할 일 만들기로 추가 기능
 // 만들기 버튼 누르면 모달 나타남
-// 할일 입력 textarea.txt-field
-// 기한 입력 button + div#drop-content.content-calendar
-// 달력에서 날짜 선택 시 버튼 textContent가 날짜로 변경
+// 1. 할일 입력 textarea.txt-field
+// 2. 기한 입력 button + div#drop-content.content-calendar
+
+// 2-2. 요일 숫자를 받으면 "ㅇ요일" 텍스트 반환 함수
+const getDayText = (dayNum) => {
+  let dayKorText = '';
+
+  switch(dayNum) {
+    case 0: 
+      dayKorText = "일요일";
+      break;
+    case 1: 
+      dayKorText = "월요일";
+      break;
+    case 2: 
+      dayKorText = "화요일";
+      break;
+    case 3:
+      dayKorText = "수요일";
+      break;
+    case 4:
+      dayKorText = "목요일";
+      break;
+    case 5:
+      dayKorText = "금요일";
+      break;
+    case 6:
+      dayKorText = "토요일";
+      break;
+  }
+  return dayKorText;
+};
+
+// 2-1. 달력에서 날짜 선택 시 버튼 textContent가 날짜로 변경하고 객체 리턴 함수
 const getSelectedDate = (e) => {
   
   // e.target이 span이면 그대로, span 상위요소면 qS로 span 선택 
@@ -24,18 +68,59 @@ const getSelectedDate = (e) => {
   console.log(selectedDay);
 
   // button.time-btn 기한 없음을 선택한 날짜로 변경
+  // 2-2. getDayText(number)로 요일 텍스트로 표시
   const $btnDate = e.target.closest('.select-time').firstElementChild;
   $btnDate.textContent 
-  = `${selectedYear}. ${selectedMonth}. ${selectedDate}`;
-
-  console.log($btnDate.textContent);
+  = `${selectedYear}. ${selectedMonth}. ${selectedDate}. ${getDayText(selectedDay)}`;
 
   // 추후 할일 객체에 날짜 추가하기 위해 객체 리턴
   return {year: selectedYear, month: selectedMonth, date: selectedDate, day: selectedDay};
-  
 }
 
-// 반복 안함 button + div#drop-content.content-repeat
+// 3. 반복 안함 button + div#drop-content.content-repeat
+// 3-1. 버튼에 선택한 반복 옵션 표시,
+//      todo 객체에 repeat 옵션값 저장
+// 0: 반복 안함, 1: 매일, 2: 매주, 3: 매월
+const getReccurrenceOption = (target) => {
+  const optionText = target.textContent;
+  let $btnRepeat = target.closest('.repeat-btn');
+  let repeatOptionNum = 0;
+
+  if(optionText === '매일') {
+    repeatOptionNum = 1;
+    $btnRepeat.textContent = '매일';
+  } else if (optionText === '매주') {
+    repeatOptionNum = 2;
+    // 가능하면 위 기한 함수 리턴되는 객체에서 day 가져오기
+    // $btnRepeat.textContent = `매주 ${dayKorText(day)}`;
+    $btnRepeat.textContent = `매주`;
+  } else if (optionText = '매월') {
+    repeatOptionNum;
+    $btnRepeat.textContent = `매월`;
+    // $btnRepeat.textContent = `매월 ${date}일`;
+  }
+  todo.repeat = repeatOptionNum;
+  console.log(todo.repeat);
+
+  // return repeatOptionNum;
+};
+// 3-2. 반복옵션에 따라 캘린더에 렌더하는 함수
+const renderRepeatToCalendarView = ({title, date, repeat}) => {
+  // 메인 캘린더의 date-container 선택
+  $dateContainer = document.querySelector('#main-content .date-container');
+  
+  const $repeatlist = document.createElement('li');
+  $repeatlist.textContent = title;
+  $repeatlist.classList.add('calendar-list');
+
+  // date-container 전체반복해서 설정한 기간보다 뒤면 리스트태그 추가
+  // new Date(date.year, date.month, date.date) 로 크기 비교
+  // ul.date-todo appendChild li태그
+  //     <li></li>
+
+
+};
+
 // 모달 저장 버튼 클릭 시 추가 완료
 
 
@@ -58,4 +143,18 @@ document.querySelector('.dropdown .go-next').parentElement.addEventListener('cli
 document.querySelector('.dropdown .date-container').addEventListener('click', e => {
   console.log("드롭다운 날짜 선택");
   getSelectedDate(e);
+});
+
+// 테스트를 위해 html script에서 가져왔습니다. 병합 시 주의!
+const $selectRepeat = document.querySelector(".select-repeat");
+const $contentRepeat = document.querySelector(".content-repeat");
+$selectRepeat.addEventListener("click", (e) => {
+  e.stopPropagation();
+  e.preventDefault();
+  $contentRepeat.classList.add("show");
+
+  // e.target 드롭다운 특정 메뉴일 때 mathces(selector)로 조건 판단
+  getReccurrenceOption(e.target);
+  console.log(e.target.textContent);
+  renderRepeatToCalendarView(todo);
 });

--- a/js/calendar_todo.js
+++ b/js/calendar_todo.js
@@ -3,16 +3,30 @@ import { goToMonth } from "./calendar.js";
 const todoList = [
   {
     title: "할일 1",
-    date: {year: 2024, month: 4, date: 21, day: 0},
-    repeat: 1
+    time: { year: 2024, month: 4, date: 1, day: 1 },
+    repeat: 1,
   },
   {
     title: "할일 2",
-    date: {year: 2024, month: 4, date: 22, day: 1},
-    repeat: 0
+    time: { year: 2024, month: 4, date: 22, day: 1 },
+    repeat: 0,
   },
-]
-let todo = {title: "할일 3", date: {year: 2024, month: 4, date: 21, day: 0}, repeat: 0};
+  {
+    title: "할일 3",
+    time: { year: 2024, month: 4, date: 10, day: 2 },
+    repeat: 2,
+  },
+  {
+    title: "할일 4",
+    time: { year: 2024, month: 4, date: 10, day: 3 },
+    repeat: 3,
+  },
+];
+let todo = {
+  title: "할일",
+  time: { year: 2024, month: 4, date: 21, day: 0 },
+  repeat: 0,
+};
 
 // 할 일 만들기로 추가 기능
 // 만들기 버튼 누르면 모달 나타남
@@ -21,16 +35,16 @@ let todo = {title: "할일 3", date: {year: 2024, month: 4, date: 21, day: 0}, r
 
 // 2-2. 요일 숫자를 받으면 "ㅇ요일" 텍스트 반환 함수
 const getDayText = (dayNum) => {
-  let dayKorText = '';
+  let dayKorText = "";
 
-  switch(dayNum) {
-    case 0: 
+  switch (dayNum) {
+    case 0:
       dayKorText = "일요일";
       break;
-    case 1: 
+    case 1:
       dayKorText = "월요일";
       break;
-    case 2: 
+    case 2:
       dayKorText = "화요일";
       break;
     case 3:
@@ -48,54 +62,65 @@ const getDayText = (dayNum) => {
   }
   return dayKorText;
 };
+// span에서 날짜 구하고 객체 리턴하는 함수
+const getDateInfoFromSpan = ($span) => {
+  const yearMonthText = $span.dataset.date; // "2024-4"
+  const selectedYear = +yearMonthText.split("-")[0]; // 2024
+  const selectedMonth = +yearMonthText.split("-")[1]; // 4
+  const selectedDate = $span.textContent;
+  const selectedDay = $span.parentElement.dataset.dateIdx % 7;
+
+  return {
+    year: selectedYear,
+    month: selectedMonth,
+    date: selectedDate,
+    day: selectedDay,
+  };
+};
 
 // 2-1. 달력에서 날짜 선택 시 버튼 textContent가 날짜로 변경하고 객체 리턴 함수
 const getSelectedDate = (e) => {
-  
-  // e.target이 span이면 그대로, span 상위요소면 qS로 span 선택 
-  const $selectedDateBox =  (e.target.matches('.date-text') && e.target) || e.target.querySelector('.date-text');
-  
-  // 달력 헤더 year-month에서 연월 가져옴
-  const yearMonthText = $selectedDateBox.closest('.monthly').querySelector('.year-month').textContent;
-  const selectedYear = yearMonthText.slice(0, 4);
-  const selectedMonth = yearMonthText.slice(-2, -1);
-  
-  // 선택한 요소의 날짜, 요일 구하기
-  const selectedDate = $selectedDateBox.textContent;
-  const selectedDay = $selectedDateBox.dataset.dateIdx % 7;
+  // e.target이 span이면 그대로, span 상위요소면 qS로 span 선택
+  const $selectedDateSpan =
+    (e.target.matches(".date-text") && e.target) ||
+    e.target.querySelector(".date-text");
 
-  console.log(selectedDate);
-  console.log(selectedDay);
+  // 달력에서 선택한 요소의 날짜, 요일 구하기
+  const {year, month, date, day} = getDateInfoFromSpan($selectedDateSpan);
 
-  // button.time-btn 기한 없음을 선택한 날짜로 변경
-  // 2-2. getDayText(number)로 요일 텍스트로 표시
-  const $btnDate = e.target.closest('.select-time').firstElementChild;
-  $btnDate.textContent 
-  = `${selectedYear}. ${selectedMonth}. ${selectedDate}. ${getDayText(selectedDay)}`;
+  // 2-2. button.time-btn 기한 없음을 선택한 날짜로 변경
+  // 2-2-1. getDayText(number) 요일 텍스트로 표시
+  const $btnTime = e.target.closest(".select-time").firstElementChild;
+  $btnTime.textContent = `${year}. ${month}. ${date}. ${getDayText(day)}`;
 
-  // 추후 할일 객체에 날짜 추가하기 위해 객체 리턴
-  return {year: selectedYear, month: selectedMonth, date: selectedDate, day: selectedDay};
-}
+  // // 추후 할일 객체에 날짜 추가하기 위해 객체 리턴
+  // return {
+  //   year: selectedYear,
+  //   month: selectedMonth,
+  //   date: selectedDate,
+  //   day: selectedDay,
+  // };
+};
 
 // 3. 반복 안함 button + div#drop-content.content-repeat
 // 3-1. 버튼에 선택한 반복 옵션 표시,
-//      todo 객체에 repeat 옵션값 저장
+//      todo 객체에 repeat 옵션값 저장 (추가/수정될 투두리스트)
 // 0: 반복 안함, 1: 매일, 2: 매주, 3: 매월
 const getReccurrenceOption = (target) => {
   const optionText = target.textContent;
-  let $btnRepeat = target.closest('.repeat-btn');
+  let $btnRepeat = target.closest(".repeat-btn");
   let repeatOptionNum = 0;
 
-  if(optionText === '매일') {
+  if (optionText === "매일") {
     repeatOptionNum = 1;
-    $btnRepeat.textContent = '매일';
-  } else if (optionText === '매주') {
+    $btnRepeat.textContent = "매일";
+  } else if (optionText === "매주") {
     repeatOptionNum = 2;
     // 가능하면 위 기한 함수 리턴되는 객체에서 day 가져오기
     // $btnRepeat.textContent = `매주 ${dayKorText(day)}`;
     $btnRepeat.textContent = `매주`;
-  } else if (optionText = '매월') {
-    repeatOptionNum;
+  } else if ((optionText = "매월")) {
+    repeatOptionNum = 3;
     $btnRepeat.textContent = `매월`;
     // $btnRepeat.textContent = `매월 ${date}일`;
   }
@@ -104,46 +129,89 @@ const getReccurrenceOption = (target) => {
 
   // return repeatOptionNum;
 };
-// 3-2. 반복옵션에 따라 캘린더에 렌더하는 함수
-const renderRepeatToCalendarView = ({title, date, repeat}) => {
-  // 메인 캘린더의 date-container 선택
-  $dateContainer = document.querySelector('#main-content .date-container');
+// 3-2. 반복옵션에 따라 캘린더 뷰에 렌더하는 함수
+// 매개변수로 todoList 가져오기
+const renderRepeatToCalendarView = (todoList) => {
+  // 메인 캘린더의 date-container 선택해서 date-box 배열로 저장
+  const dateBoxArr = Array.from(document.querySelector("#main-content .date-container").children);
   
-  const $repeatlist = document.createElement('li');
-  $repeatlist.textContent = title;
-  $repeatlist.classList.add('calendar-list');
+  const viewTimeArr = dateBoxArr.map(dateBox => {
+    const {year, month, date} = getDateInfoFromSpan(dateBox.firstElementChild);
+    const dateBoxId = dateBox.dataset.dateIdx;
+    return { dateObj: new Date(year, month, date), dateBoxId };
+  });
+
+  todoList.forEach((todo) => {
+    // todo의 날짜 구하기
+    const todoTime = new Date(todo.time.year, todo.time.month -1, todo.time.date).getTime();
+    
+    // todo의 repeat 값 따라 리스트 추가할 날짜만 필터
+    const filteredViewTimeArr = viewTimeArr.filter(({dateObj: viewTime}, dateBoxId) => {
+      let option = todo.repeat;
+      // 매일 반복은 todoTime 이상의 viewTime만 필터링
+      if(option === 1) return viewTime.getTime() >= todoTime;
+      // 매주 반복은 todoTime 이상의 viewTime이면서 요일이 같을 때만 필터링
+      else if(option === 2) {
+        console.log(todo.time.day);
+        return viewTime.getTime() >= todoTime && todo.time.day === viewTime.getDay();
+      }
+      // 매월 반복은 todoTime 이상의 viewTime이면서 날짜가 같을 때만 필터링
+      else if(option === 3) return viewTime.getTime() >= todoTime && todo.time.date === viewTime.getDate();
+      else if(option === 0)return viewTime.getTime() === todoTime;  
+      else return false;
+    });
+    
+
+    // todo 정보를 li 태그에 담기
+    
+    // 해당 날짜의 ul 자식요소로 li 태그 추가
+    filteredViewTimeArr.forEach( ({dateBoxId}) => {
+      const $repeatLi = document.createElement("li");
+      $repeatLi.textContent = todo.title;
+      $repeatLi.classList.add("cal-list");
+
+      const $ul = dateBoxArr[0].parentElement.querySelector(`div[data-date-Idx="${dateBoxId}"] ul`);
+      $ul.appendChild($repeatLi);
+      if($ul.previousElementSibling.classList.contains('inactive')) {
+        $ul.classList.add('inactive');
+      }
+      // console.log($ul);
+    });
+  });
+
 
   // date-container 전체반복해서 설정한 기간보다 뒤면 리스트태그 추가
   // new Date(date.year, date.month, date.date) 로 크기 비교
   // ul.date-todo appendChild li태그
-  //     <li></li>
-
 
 };
 
 // 모달 저장 버튼 클릭 시 추가 완료
 
-
-
 //===== 함수 실행 영역 =====//
 
-
 // 드롭다운 이전 달 버튼 클릭 이벤트 핸들러
-document.querySelector('.dropdown .go-prev').parentElement.addEventListener('click', () => {
-  console.log("이전버튼");
-  goToMonth(-1); // 방향을 -1로 설정하여 이전 달로 이동
-});
+document
+  .querySelector(".dropdown .go-prev")
+  .parentElement.addEventListener("click", () => {
+    console.log("이전버튼");
+    goToMonth(-1); // 방향을 -1로 설정하여 이전 달로 이동
+  });
 
 // 드롭다운 다음 달 버튼 클릭 이벤트 핸들러
-document.querySelector('.dropdown .go-next').parentElement.addEventListener('click', () => {
-  console.log("다음버튼");
-  goToMonth(1); // 방향을 1로 설정하여 다음 달로 이동
-});
+document
+  .querySelector(".dropdown .go-next")
+  .parentElement.addEventListener("click", () => {
+    console.log("다음버튼");
+    goToMonth(1); // 방향을 1로 설정하여 다음 달로 이동
+  });
 
-document.querySelector('.dropdown .date-container').addEventListener('click', e => {
-  console.log("드롭다운 날짜 선택");
-  getSelectedDate(e);
-});
+document
+  .querySelector(".dropdown .date-container")
+  .addEventListener("click", (e) => {
+    console.log("드롭다운 날짜 선택");
+    getSelectedDate(e);
+  });
 
 // 테스트를 위해 html script에서 가져왔습니다. 병합 시 주의!
 const $selectRepeat = document.querySelector(".select-repeat");
@@ -153,8 +221,12 @@ $selectRepeat.addEventListener("click", (e) => {
   e.preventDefault();
   $contentRepeat.classList.add("show");
 
-  // e.target 드롭다운 특정 메뉴일 때 mathces(selector)로 조건 판단
+  // e.target 드롭다운 옵션 조건 판단
+
   getReccurrenceOption(e.target);
-  console.log(e.target.textContent);
-  renderRepeatToCalendarView(todo);
+  
 });
+// 투두리스트 추가 수정 삭제 마다 render
+renderRepeatToCalendarView(todoList);
+
+export {todoList, renderRepeatToCalendarView};

--- a/js/calendar_todo.js
+++ b/js/calendar_todo.js
@@ -117,21 +117,29 @@ const getSelectedDate = (e) => {
 //      todo 객체에 repeat 옵션값 저장 (추가/수정될 투두리스트)
 // 0: 반복 안함, 1: 매일, 2: 매주, 3: 매월
 const setReccurrenceOption = (target) => {
-  const optionText = target.textContent;
-  let $btnRepeat = target.closest(".repeat-btn");
+  // e.target이 a이면 그대로, a 상위요소면 qS로 a 선택
+  const $selectedOption =
+  (target.matches(".repeat-option") && target) ||
+  target.querySelector(".repeat-option");
+
+  // optionText와 반복 버튼의 텍스트요소 가져오기
+  let optionText = $selectedOption.textContent;
+  let $btnRepeat = document.querySelector("button.repeat-btn");
   let repeatOptionNum = 0;
 
+  // 옵션에 따라 버튼 텍스트 변경 및 
+  //           todo객체에 repeat키 값 저장
   if (optionText === "매일") {
     repeatOptionNum = 1;
-    $btnRepeat.textContent = "매일";
+    $btnRepeat.textContent = optionText;
   } else if (optionText === "매주") {
     repeatOptionNum = 2;
-    // 가능하면 위 기한 함수 리턴되는 객체에서 day 가져오기
+    // 가능하면 todo 객체에서 day 가져오기
     // $btnRepeat.textContent = `매주 ${dayKorText(day)}`;
-    $btnRepeat.textContent = `매주`;
+    $btnRepeat.textContent = optionText;
   } else if ((optionText = "매월")) {
     repeatOptionNum = 3;
-    $btnRepeat.textContent = `매월`;
+    $btnRepeat.textContent = optionText;
     // $btnRepeat.textContent = `매월 ${date}일`;
   }
   todo.repeat = repeatOptionNum;
@@ -241,9 +249,15 @@ $selectRepeat.addEventListener("click", (e) => {
   e.preventDefault();
   $contentRepeat.classList.add("show");
 
+  
+});
+$contentRepeat.addEventListener("click", e => {
+
+  console.log("a 선택");
+  console.log(e.target);
   // e.target 드롭다운 옵션 조건 판단
   setReccurrenceOption(e.target);
-  
+
 });
 // 투두리스트 추가 수정 삭제 마다 render 해야 함
 renderRepeatToCalendarView(todoList);


### PR DESCRIPTION
calendar 페이지에 일정 렌더링 기능

setReccurrenceOption 함수
- 모달에서 반복옵션 클릭 시 todo 객체에 저장
- 모달 반복 버튼 텍스트로 선택한 옵션이 표시됨

renderRepeatToCalendarView 함수
- 반복옵션에 따라 현재의 캘린더뷰에 일치하는 모든 일정 표시
- generateViewTimeArray 함수로 현재 캘린더뷰 기준 Date() 객체 배열로 생성
- todoList 의 todo 마다 Date배열 필터링해서 일정을 li 태그로 추가
       - filterViewTimeArray 함수 : Date배열을 옵션에 따라 필터링
       - renderTodoItems 함수 : 필터링된 날짜 ul 자식으로 li 태그 추가

스타일 및 구조 일부 수정
- calendar.html에서 모달 반복옵션 태그 일부 수정
- calendar.css 일부 수정

![image](https://github.com/calenderProjectJS/Calendar/assets/157199245/c1fa8157-2156-48a0-aa4c-94886e1e8739)
